### PR TITLE
redirection fix

### DIFF
--- a/main.php
+++ b/main.php
@@ -327,6 +327,7 @@ class Mytory_Markdown {
         curl_setopt($curl, CURLOPT_URL, $url);
         curl_setopt($curl, CURLOPT_HEADER, FALSE);
         curl_setopt($curl, CURLOPT_NOBODY, FALSE);
+        curl_setopt($curl, CURLOPT_FOLLOWLOCATION, TRUE);
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, TRUE);
         $content = curl_exec($curl);
 


### PR DESCRIPTION
This will fix the troubles with dropbox links. HOWEVER, as stated by someone else:

```
Warning: curl_setopt(): CURLOPT_FOLLOWLOCATION cannot be activated when safe_mode is enabled or an open_basedir is set in /var/www/wp-content/plugins/mytory-markdown/main.php on line 308
```

PHP Safe mode must be disabled for this to work.
